### PR TITLE
Breakpoint hit hook

### DIFF
--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -84,6 +84,8 @@ void gdbstub_term(gdbstub_t * gdb);
 
 void gdbstub_tick(gdbstub_t * gdb);
 
+void gdbstub_breakpoint_hit(gdbstub_t * gdb);
+
 #endif // GDBSTUB_H
 
 #ifdef GDBSTUB_IMPLEMENTATION
@@ -252,6 +254,11 @@ void gdbstub_tick(gdbstub_t * gdb)
     else {
         _gdbstub_recv(gdb);
     }
+}
+
+void gdbstub_breakpoint_hit(gdbstub_t * gdb) {
+    _gdbstub_send(gdb, "T05", 3);
+    return;
 }
 
 void _gdbstub_send(gdbstub_t * gdb, const char * data, size_t data_length)

--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -258,7 +258,6 @@ void gdbstub_tick(gdbstub_t * gdb)
 
 void gdbstub_breakpoint_hit(gdbstub_t * gdb) {
     _gdbstub_send(gdb, "T05", 3);
-    return;
 }
 
 void _gdbstub_send(gdbstub_t * gdb, const char * data, size_t data_length)


### PR DESCRIPTION
The target should halt when a breakpoint is hit, and tell GDB that it halted / why it halted.