### PR TITLE
gdbstub.h: Fix GDB Interrupt Packet handling

### DIFF
--- a/include/gdbstub.h
+++ b/include/gdbstub.h
@@ -337,7 +337,9 @@ void _gdbstub_recv(gdbstub_t * gdb)
                 gdb->packet_checksum = 0;
             }
             else if (c == 3) {
-                // TODO: investigate
+                // GDB Interrupt '0x03' Packet
+                gdb->config.stop(gdb->config.user_data);
+                _gdbstub_send(gdb, "S00", 3);
             }
             break;
         case GDB_STATE_IN_PACKET:


### PR DESCRIPTION
Whenever an interrupt signal is fired from within GDB (Ctrl+C for example), it sends a simple packet w/the value 0x03; to handle such case we expand the current impl. w/a user designated option (Could be the user-defined stop method) and we send a SIGINT signal ("S02", but could be any other permitted value).

I'm not sure how the maintainers want to handle the user-defined option to handle gdb interrupts (I use gdb->config.stop(gdb->config.user_data) because it works on my current setup) so if it needs something more generic we can change it.